### PR TITLE
Modified  to support queries using the "*:*" notation

### DIFF
--- a/imaplib2/imaplib2.py
+++ b/imaplib2/imaplib2.py
@@ -280,7 +280,7 @@ class IMAP4(object):
         # Need to quote "atom-specials" :-
         #   "(" / ")" / "{" / SP / 0x00 - 0x1f / 0x7f / "%" / "*" / DQUOTE / "\" / "]"
         # so match not the inverse set
-    mustquote_cre = re.compile(r"[^!#$&'+,./0-9:;<=>?@A-Z\[^_`a-z|}~-]")
+    mustquote_cre = re.compile(r"[^!#$&'*+,./0-9:;<=>?@A-Z\[^_`a-z|}~-]")
     response_code_cre = re.compile(r'\[(?P<type>[A-Z-]+)( (?P<data>[^\]]*))?\]')
     # sequence_set_cre = re.compile(r"^[0-9]+(:([0-9]+|\*))?(,[0-9]+(:([0-9]+|\*))?)*$")
     untagged_response_cre = re.compile(r'\* (?P<type>[A-Z-]+)( (?P<data>.*))?')


### PR DESCRIPTION
In imaplib, this works:

M.select(mailbox,readonly=True)
status, data = M.uid('FETCH', '1:*' , '(RFC822)')

Here is the docs where it shows how to use the command: http://docs.python.org/2/library/imaplib.html#imap4-objects .

I modified the mustquote regex to also support these style of commands.
