### PR TITLE
Add trove classifiers to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,13 @@ from setuptools import setup, find_packages
 
 setup(
     name="imaplib2",
-    version="2.28.1",
+    version="2.28.2",
     description="A threaded Python IMAP4 client.",
     author="Piers Lauder",
     url="http://github.com/bcoe/imaplib2",
+    classifiers = [
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7"
+    ],
     packages = find_packages()
 )


### PR DESCRIPTION
PyPi currently thinks that the imaplib2 package is compatible with Python 3. I think adding trove classifiers specifying it currently only works with Python 2 should fix this. I also tried to be more specific by adding Python 2.7 which maybe isn't necessary.
