### PR TITLE
Add support for Python 3 by doing 2to3 conversion on package install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python
-#from distutils.core import setup
+# from distutils.core import setup
 from setuptools import setup, find_packages
+
+try:
+    from distutils.command.build_py import build_py_2to3 as build_py
+except ImportError:
+    from distutils.command.build_py import build_py
 
 setup(
     name="imaplib2",
-    version="2.28.3",
+    version="2.28.4",
     description="A threaded Python IMAP4 client.",
     author="Piers Lauder",
     url="http://github.com/bcoe/imaplib2",
-    classifiers = [
+    classifiers=[
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7"
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3"
     ],
-    packages = find_packages()
+    packages=find_packages(),
+    cmdclass={'build_py': build_py}
 )


### PR DESCRIPTION
According to http://python3porting.com/2to3.html#running-2to3-on-install this is an easy way to maintain compatibility for both Python 2.x and 3.x without requiring separate packages, separate source trees, or separate submissions.

I also fixed up setup.py so it was PEP8 compliant, added the appropriate trove classifier to indicate Python 3 support, and bumped the version number.
