### PR TITLE
2to3 no longer needed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,6 @@
 # from distutils.core import setup
 from setuptools import setup, find_packages
 
-try:
-    from distutils.command.build_py import build_py_2to3 as build_py
-except ImportError:
-    from distutils.command.build_py import build_py
-
 setup(
     name="imaplib2",
     version="2.38.0",
@@ -19,5 +14,4 @@ setup(
         "Programming Language :: Python :: 3"
     ],
     packages=find_packages(),
-    cmdclass={'build_py': build_py}
 )


### PR DESCRIPTION
Python 3 is supported natively now.

Also wheel support!

```bash
pip install -U pip setuptools wheel
python setup.py sdist bdist_wheel register upload
```